### PR TITLE
Fix typo in pod

### DIFF
--- a/lib/Catmandu/Store/ElasticSearch.pm
+++ b/lib/Catmandu/Store/ElasticSearch.pm
@@ -290,7 +290,7 @@ name of the store, C<search> in this case:
 
 This store expects version 1.0 or higher of the Elasticsearch server.
 
-To talk to older versions of Elasticsearch the approriate client should be installed.
+To talk to older versions of Elasticsearch the appropriate client should be installed.
 
     # Elasticsearch 2.x
     cpanm Search::Elasticsearch::Client::2_0::Direct


### PR DESCRIPTION
spelling-error-in-manpage found by lintian while building Debian package