### PR TITLE
_parse_term_node not only returns query, but also modifies it in place

### DIFF
--- a/lib/Catmandu/Store/ElasticSearch/CQL.pm
+++ b/lib/Catmandu/Store/ElasticSearch/CQL.pm
@@ -80,7 +80,8 @@ sub _parse_term_node {
     my $term = $node->getTerm;
 
     if ($term =~ $RE_MATCH_ALL) {
-        return {match_all => {}};
+        $query->{match_all} = +{};
+        return $query;
     }
 
     my $qualifier = $node->getQualifier;


### PR DESCRIPTION
A CQL query like `cql.allRecords` is now translated into `{}` (empty hash).

Reason: line https://github.com/LibreCat/Catmandu-Store-Elasticsearch/blob/main/lib/Catmandu/Store/ElasticSearch/CQL.pm#L39 expects the methods to modify the provided `$query` inline (it ignores return values), but https://github.com/LibreCat/Catmandu-Store-Elasticsearch/blob/main/lib/Catmandu/Store/ElasticSearch/CQL.pm#L83 returns only the new query,
instead of also modifying it.

Test:

```
my $bag = Catmandu->store("search")->bag("publication");
my $es_query = $bag->translate_cql_query('cql.allRecords');
```